### PR TITLE
Feature issue 2 gau fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Service for generating webhook tokens and accepting webhooks data
 POST: https://webhook.mydomain.gaiahub.io/wh/config
     Content-Type: application/json
     Accept: application/json
+    X-ORIG-SERVER: <mydomain.gaiahub.io>
     Authorization: Bearer <accesstoken>
     { "datasource":"github",
       "event": "push",

--- a/controllers/webhook-controller.js
+++ b/controllers/webhook-controller.js
@@ -98,9 +98,9 @@ router.post('/wh/config', function (req, res) {
                 respBody.tenantId = req.oauth.bearerToken.tenantId;
                 respBody.token = crypto.createSHA1(datasource, eventType, respBody.tenantId, currentTime);
                 if(req.get('Host').startsWith('webhook')){
-                    respBody.hookUrl = 'https://' + req.get('Host') + '/wh/' + respBody.apiToken + '/' + respBody.token;
+                    respBody.hookUrl = 'https://' + req.get('X-ORIG-SERVER') + '/wh/' + respBody.apiToken + '/' + respBody.token;
                 } else {
-                    respBody.hookUrl = 'https://webhook.' + req.get('Host') + '/wh/' + respBody.apiToken + '/' + respBody.token;
+                    respBody.hookUrl = 'https://webhook.' + req.get('X-ORIG-SERVER') + '/wh/' + respBody.apiToken + '/' + respBody.token;
                 }
             }
             Q.fcall(db.add, respBody.token, JSON.stringify(respBody)).then(function () {

--- a/controllers/webhook-controller.js
+++ b/controllers/webhook-controller.js
@@ -73,7 +73,11 @@ router.post('/wh/config', function (req, res) {
                 respBody.apiToken = req.oauth.bearerToken.accessToken;
                 respBody.tenantId = req.oauth.bearerToken.tenantId;
                 respBody.token = data4.token;
-                respBody.hookUrl = 'https://' + req.get('Host') + '/wh/' + respBody.apiToken + '/' + respBody.token;
+                if(req.get('X-ORIG-SERVER').startsWith('webhook')){
+                    respBody.hookUrl = 'https://' + req.get('X-ORIG-SERVER') + '/wh/' + respBody.apiToken + '/' + respBody.token;
+                } else {
+                    respBody.hookUrl = 'https://webhook.' + req.get('X-ORIG-SERVER') + '/wh/' + respBody.apiToken + '/' + respBody.token;
+                }
                 if (typeof timestampField === 'undefined' || timestampField === null) {
                     //if no timestampField or sent null, continue using the existing one
                     respBody.tsField = data4.tsField;
@@ -97,7 +101,7 @@ router.post('/wh/config', function (req, res) {
                 respBody.apiToken = req.oauth.bearerToken.accessToken;
                 respBody.tenantId = req.oauth.bearerToken.tenantId;
                 respBody.token = crypto.createSHA1(datasource, eventType, respBody.tenantId, currentTime);
-                if(req.get('Host').startsWith('webhook')){
+                if(req.get('X-ORIG-SERVER').startsWith('webhook')){
                     respBody.hookUrl = 'https://' + req.get('X-ORIG-SERVER') + '/wh/' + respBody.apiToken + '/' + respBody.token;
                 } else {
                     respBody.hookUrl = 'https://webhook.' + req.get('X-ORIG-SERVER') + '/wh/' + respBody.apiToken + '/' + respBody.token;

--- a/test/integration/webhook-controller-test.js
+++ b/test/integration/webhook-controller-test.js
@@ -282,6 +282,7 @@ describe('webhook tests', function () {
                 headers: {
                     'Content-Type': 'application/json',
                     'Accept': 'application/json',
+                    'X-ORIG-SERVER': 'localhost',
                     'Authorization': 'Bearer ' + accessToken
                 },
                 json: {
@@ -294,11 +295,11 @@ describe('webhook tests', function () {
                 expect(res.statusCode).to.equal(200);
                 webHookToken = body.token;
                 //returned URL is aligned for proxied environment
-                expect(body.hookUrl).to.equal('https://webhook.localhost:3000/wh/' + accessToken + '/' + webHookToken);
+                expect(body.hookUrl).to.equal('https://webhook.localhost/wh/' + accessToken + '/' + webHookToken);
                 expect(body.tenantId).to.equal(tenantId);
                 expect(body.datasource).to.equal('github');
                 expect(body.event).to.equal('push');
-                initialWebhookUrl = 'https://localhost:3000/wh/' + accessToken + '/' + webHookToken;
+                initialWebhookUrl = 'https://webhook.localhost/wh/' + accessToken + '/' + webHookToken;
                 initialDatasource = body.datasource;
                 initialEventType = body.event;
                 done();
@@ -404,6 +405,7 @@ describe('webhook tests', function () {
                 headers: {
                     'Content-Type': 'application/json',
                     'Accept': 'application/json',
+                    'X-ORIG-SERVER': 'localhost',
                     'Authorization': 'Bearer ' + accessToken
                 },
                 json: {
@@ -432,6 +434,7 @@ describe('webhook tests', function () {
                 headers: {
                     'Content-Type': 'application/json',
                     'Accept': 'application/json',
+                    'X-ORIG-SERVER': 'localhost',
                     'Authorization': 'Bearer ' + accessToken
                 },
                 json: {
@@ -459,6 +462,7 @@ describe('webhook tests', function () {
                 headers: {
                     'Content-Type': 'application/json',
                     'Accept': 'application/json',
+                    'X-ORIG-SERVER': 'localhost',
                     'Authorization': 'Bearer ' + accessToken
                 },
                 json: {

--- a/webhook-service.service
+++ b/webhook-service.service
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [Unit]
-Description=Gaia Task Configuration Service
+Description=Gaia Webhook Service
 Documentation=https://github.com/gaia-adm/webhook-service
 
 After=registrator.service


### PR DESCRIPTION
Use the original server name delivered in X-ORIG-SERVER header (created by GAU in the deployment or set manually in the Rest client) when generating a webhook URL. This name is the same as the domain name of the system.
